### PR TITLE
Replay download from api v1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ RUST_LOG = "shishabot=debug,info" # could just be "info" on release
 # Tokens
 DISCORD_TOKEN = ""
 OSU_CLIENT_ID = 123
-OSU_SESSION_COOKIE = ""
+OSU_API_KEY = ""
 
 # Replay Upload
 UPLOAD_SECRET = ""

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,19 +17,19 @@ futures = { version = "0.3", default-features = false }
 http = { version = "0.2" }
 hyper = { version = "0.14", default-features = false }
 hyper-rustls = { version = "0.23", default-features = false, features = ["http1", "tls12", "tokio-runtime", "webpki-tokio"] }
-leaky-bucket-lite = { version = "0.5", features = ["parking_lot"] }
+leaky-bucket-lite = { version = "0.5" }
 once_cell = { version = "1.0" }
 osu-db = { version = "0.3", default-features = false }
 radix_trie = { version = "0.2" }
 rand = { version = "0.8" }
-rosu-v2 = { git = "https://github.com/MaxOhn/rosu-v2", branch = "next", features = ["metrics", "rkyv"] }
+rosu-v2 = { git = "https://github.com/MaxOhn/rosu-v2", branch = "next", default-features = false }
 rosu-pp = { git = "https://github.com/MaxOhn/rosu-pp", branch = "next", features = ["async_tokio"] }
-serde = { version = "1.0", features = ["derive", "rc"] }
+serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 smallstr = { version = "0.2", features = ["serde"] }
 smallvec = { version = "1.0", features = ["serde"] }
 time = { version = "0.3.14", features = ["macros", "parsing", "formatting"] }
-tokio = { version = "1.20", default-features = false, features = ["fs", "io-util", "macros", "parking_lot", "process", "rt-multi-thread", "signal", "sync", "time"] }
+tokio = { version = "1.20", default-features = false, features = ["fs", "io-util", "macros", "process", "rt-multi-thread", "signal", "sync", "time"] }
 tracing = { version = "0.1" }
 tracing-appender = { version = "0.2" }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt", "smallvec", "std", "time", "tracing-log"] }

--- a/src/commands/danser/render_from_bathbot_embed.rs
+++ b/src/commands/danser/render_from_bathbot_embed.rs
@@ -1,13 +1,19 @@
-use std::{str::FromStr, sync::Arc};
+use std::{fs, str::FromStr, sync::Arc};
 
 use command_macros::msg_command;
-use eyre::Context as _;
-use time::{format_description::well_known::Iso8601, OffsetDateTime};
+use eyre::{Context as _, Report};
+use osu_db::Replay;
+use rosu_v2::prelude::Score;
+use time::{
+    format_description::well_known::Iso8601, Date, OffsetDateTime, PrimitiveDateTime, Time,
+};
 use twilight_model::{channel::embed::Embed, util::Timestamp};
 
 use crate::{
-    core::{BotConfig, Context, ReplayData, TimePoints},
-    util::{builder::MessageBuilder, interaction::InteractionCommand, InteractionCommandExt},
+    core::{replay_queue::ReplaySlim, BotConfig, Context, ReplayData, TimePoints},
+    util::{
+        builder::MessageBuilder, interaction::InteractionCommand, Authored, InteractionCommandExt,
+    },
 };
 
 #[msg_command(name = "Render score", dm_permission = false)]
@@ -59,7 +65,7 @@ async fn render_from_msg(ctx: Arc<Context>, mut command: InteractionCommand) -> 
         }
     };
 
-    let osu_user_id = match osu_user_url.split("/").nth(4) {
+    let osu_user_id = match osu_user_url.split('/').nth(4) {
         Some(id) => match id.parse::<u32>() {
             Ok(id) => id,
             Err(_) => {
@@ -101,72 +107,98 @@ async fn render_from_msg(ctx: Arc<Context>, mut command: InteractionCommand) -> 
         },
     };
 
-    let mut score_to_render: Option<rosu_v2::prelude::Score> = None;
     let ts_unix = OffsetDateTime::from_unix_timestamp(timestamp.as_secs())
         .unwrap()
         .unix_timestamp();
 
     // check recents
-    let recent_scores = ctx.osu().user_scores(osu_user_id).recent().await?;
+    let recent_scores = ctx
+        .osu()
+        .user_scores(osu_user_id)
+        .recent()
+        .limit(100)
+        .await
+        .context("failed to get recent scores")?;
 
-    for score in recent_scores {
-        let score_ts = score.ended_at.unix_timestamp();
-        if (score_ts - ts_unix).abs() <= 3 && score.replay.unwrap_or(false) {
-            score_to_render = Some(score);
-            break;
-        }
-    }
+    let score_to_render = recent_scores.into_iter().find(|score| {
+        (score.ended_at.unix_timestamp() - ts_unix).abs() <= 3 && score.replay.unwrap_or(false)
+    });
 
     // check tops
-    if score_to_render.is_none() {
-        let top_scores = ctx.osu().user_scores(osu_user_id).best().await?;
+    let score_to_render = match score_to_render {
+        Some(score) => score,
+        None => {
+            let top_scores = ctx
+                .osu()
+                .user_scores(osu_user_id)
+                .best()
+                .limit(100)
+                .await
+                .context("failed to get top scores")?;
 
-        for score in top_scores {
-            let score_ts = score.ended_at.unix_timestamp();
-            if (score_ts - ts_unix).abs() <= 3 && score.replay.unwrap_or(false) {
-                score_to_render = Some(score);
-                break;
+            let score_opt = top_scores.into_iter().find(|score| {
+                (score.ended_at.unix_timestamp() - ts_unix).abs() <= 3
+                    && score.replay.unwrap_or(false)
+            });
+
+            match score_opt {
+                Some(score) => score,
+                None => {
+                    let content = "Couldn't find the replay for this score";
+                    command.error(&ctx, content).await?;
+
+                    return Ok(());
+                }
             }
         }
+    };
 
-        if score_to_render.is_none() {
-            command
-                .error(&ctx, "Couldn't find the replay for this score")
-                .await?;
-            return Ok(());
-        }
-    }
+    let score_id = score_to_render.score_id;
 
-    let score_id = score_to_render.unwrap().score_id;
-    let replay = ctx
+    let mut replay_bytes = ctx
         .client()
-        .get_osu_replay(score_id)
+        .get_raw_replay(score_to_render.score_id)
         .await
-        .context("failed to get replay")?;
+        .context("failed to get replay bytes")?;
 
-    let input_channel = command.channel_id;
-    let user = command.member.as_ref().unwrap().user.as_ref().unwrap().id;
-    let output_channel = ctx
-        .http
-        .create_private_channel(user)
-        .exec()
-        .await?
-        .model()
-        .await?
-        .id;
+    extend_replay_bytes(&mut replay_bytes, &score_to_render);
 
     let mut path = BotConfig::get().paths.downloads();
     path.push(format!("{score_id}.osr"));
 
-    let time_points = TimePoints { start: 0, end: 0 };
+    fs::write(&path, &replay_bytes).context("failed to write into replay file")?;
+
+    let replay = match Replay::from_bytes(&replay_bytes) {
+        Ok(replay) => ReplaySlim::from(replay),
+        Err(err) => {
+            let content = "Failed to parse replay";
+            let _ = command.error(&ctx, content).await;
+
+            return Err(Report::new(err).wrap_err("failed to parse replay"));
+        }
+    };
+
+    let input_channel = command.channel_id;
+    let user = command.user_id()?;
+
+    let output_channel = ctx
+        .http
+        .create_private_channel(user)
+        .exec()
+        .await
+        .context("failed to create private channel")?
+        .model()
+        .await
+        .context("failed to deserialize private channel")?
+        .id;
 
     let replay_data = ReplayData {
         input_channel,
         output_channel,
         path,
         replay,
-        time_points,
         user,
+        time_points: TimePoints { start: 0, end: 0 },
     };
 
     ctx.replay_queue.push(replay_data).await;
@@ -180,7 +212,7 @@ async fn render_from_msg(ctx: Arc<Context>, mut command: InteractionCommand) -> 
 fn get_timestamp_from_minimized_embed(embed: &Embed) -> Option<Timestamp> {
     let field = embed.fields.first()?;
 
-    let discord_timestamp = field.name.split("\t").last()?;
+    let discord_timestamp = field.name.split('\t').last()?;
 
     let actual_timestamp_value = discord_timestamp
         .trim_start_matches("<t:")
@@ -199,7 +231,148 @@ fn get_timestamp_from_minimized_embed(embed: &Embed) -> Option<Timestamp> {
     };
 
     match Timestamp::from_str(&datetime_formatted) {
-        Ok(timestamp) => return Some(timestamp),
-        Err(_) => return None,
-    };
+        Ok(timestamp) => Some(timestamp),
+        Err(_) => None,
+    }
+}
+
+// https://osu.ppy.sh/wiki/en/Client/File_formats/Osr_%28file_format%29
+fn extend_replay_bytes(bytes: &mut Vec<u8>, score: &Score) {
+    let initial_len = bytes.len();
+    let mut bytes_written = 0;
+
+    bytes_written += encode_byte(bytes, score.mode as u8);
+    bytes_written += encode_int(bytes, game_version(score.ended_at.date()));
+
+    let map_md5 = score
+        .map
+        .as_ref()
+        .and_then(|map| map.checksum.as_deref())
+        .unwrap_or_default();
+
+    bytes_written += encode_string(bytes, map_md5);
+
+    let username = score
+        .user
+        .as_ref()
+        .map(|user| user.username.as_str())
+        .unwrap_or_default();
+
+    bytes_written += encode_string(bytes, username);
+
+    let replay_md5 = String::new();
+    bytes_written += encode_string(bytes, &replay_md5);
+
+    let stats = &score.statistics;
+    bytes_written += encode_short(bytes, stats.count_300 as u16);
+    bytes_written += encode_short(bytes, stats.count_100 as u16);
+    bytes_written += encode_short(bytes, stats.count_50 as u16);
+    bytes_written += encode_short(bytes, stats.count_geki as u16);
+    bytes_written += encode_short(bytes, stats.count_katu as u16);
+    bytes_written += encode_short(bytes, stats.count_miss as u16);
+
+    bytes_written += encode_int(bytes, score.score);
+
+    bytes_written += encode_short(bytes, score.max_combo as u16);
+
+    bytes_written += encode_byte(bytes, score.perfect as u8);
+
+    bytes_written += encode_int(bytes, score.mods.bits());
+
+    let lifebar = String::new();
+    bytes_written += encode_string(bytes, &lifebar);
+
+    bytes_written += encode_datetime(bytes, score.ended_at);
+
+    bytes_written += encode_int(bytes, initial_len as u32);
+
+    bytes.rotate_right(bytes_written);
+
+    encode_long(bytes, score.score_id);
+}
+
+fn encode_byte(bytes: &mut Vec<u8>, byte: u8) -> usize {
+    bytes.push(byte);
+
+    1
+}
+
+fn encode_short(bytes: &mut Vec<u8>, short: u16) -> usize {
+    bytes.extend_from_slice(&short.to_le_bytes());
+
+    2
+}
+
+fn encode_int(bytes: &mut Vec<u8>, int: u32) -> usize {
+    bytes.extend_from_slice(&int.to_le_bytes());
+
+    4
+}
+
+fn encode_long(bytes: &mut Vec<u8>, long: u64) -> usize {
+    bytes.extend_from_slice(&long.to_le_bytes());
+
+    8
+}
+
+fn encode_string(bytes: &mut Vec<u8>, s: &str) -> usize {
+    if s.is_empty() {
+        bytes.push(0x00); // "no string"
+
+        1
+    } else {
+        bytes.push(0x0b); // "string incoming"
+        let len = encode_leb128(bytes, s.len());
+        bytes.extend_from_slice(s.as_bytes());
+
+        1 + len + s.len()
+    }
+}
+
+// https://en.wikipedia.org/wiki/LEB128
+fn encode_leb128(bytes: &mut Vec<u8>, mut n: usize) -> usize {
+    let mut bytes_written = 0;
+
+    loop {
+        let mut byte = ((n & u8::MAX as usize) as u8) & !(1 << 7);
+        n >>= 7;
+
+        if n != 0 {
+            byte |= 1 << 7;
+        }
+
+        bytes.push(byte);
+        bytes_written += 1;
+
+        if n == 0 {
+            return bytes_written;
+        }
+    }
+}
+
+// https://docs.microsoft.com/en-us/dotnet/api/system.datetime.ticks?redirectedfrom=MSDN&view=net-6.0#System_DateTime_Ticks
+fn encode_datetime(bytes: &mut Vec<u8>, datetime: OffsetDateTime) -> usize {
+    let orig_date = Date::from_ordinal_date(1, 1).unwrap();
+    let orig_time = Time::from_hms(0, 0, 0).unwrap();
+
+    let orig = PrimitiveDateTime::new(orig_date, orig_time).assume_utc();
+
+    let orig_nanos = orig.unix_timestamp_nanos();
+    let this_nanos = datetime.unix_timestamp_nanos();
+
+    let long = (this_nanos - orig_nanos) / 100;
+
+    encode_long(bytes, long as u64)
+}
+
+fn game_version(date: Date) -> u32 {
+    let mut version = date.year() as u32;
+    version *= 100;
+
+    version += date.month() as u32;
+    version *= 100;
+
+    version += date.day() as u32;
+
+    version
 }

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -72,7 +72,7 @@ pub struct Tokens {
     pub discord: String,
     pub osu_client_id: u64,
     pub osu_client_secret: String,
-    pub osu_session_cookie: String,
+    pub osu_api_key: String,
     pub upload_secret: String,
 }
 
@@ -96,7 +96,7 @@ impl BotConfig {
                 discord: env_var("DISCORD_TOKEN")?,
                 osu_client_id: env_var("OSU_CLIENT_ID")?,
                 osu_client_secret: env_var("OSU_CLIENT_SECRET")?,
-                osu_session_cookie: env_var("OSU_SESSION_COOKIE")?,
+                osu_api_key: env_var("OSU_API_KEY")?,
                 upload_secret: env_var("UPLOAD_SECRET")?,
             },
             paths: Paths {


### PR DESCRIPTION
Using the api v1 instead of the website api to download replays.
Requires `.env` to contain an `OSU_API_KEY` variable.

Also cleaned up dependencies a little.