### PR TITLE
Sanitized logging

### DIFF
--- a/src/core/logging.rs
+++ b/src/core/logging.rs
@@ -1,6 +1,9 @@
-use std::fmt;
+use std::fmt::Result as FmtResult;
 
-use time::{format_description::FormatItem, macros::format_description};
+use time::format_description::{
+    modifier::{Day, Hour, Minute, Month, Second, Year},
+    Component, FormatItem,
+};
 use tracing::{Event, Subscriber};
 use tracing_appender::{
     non_blocking::{NonBlocking, WorkerGuard},
@@ -14,44 +17,56 @@ use tracing_subscriber::{
     },
     layer::SubscriberExt,
     registry::LookupSpan,
-    EnvFilter, FmtSubscriber,
+    util::SubscriberInitExt,
+    EnvFilter, Layer as _,
 };
 
-pub fn initialize() -> WorkerGuard {
-    let formatter = format_description!("[year]-[month]-[day] [hour]:[minute]:[second]");
+pub fn init() -> WorkerGuard {
+    // Displays ERROR, WARN, INFO, and DEBUG from shishabot
+    // and ERROR, WARN, INFO from dependencies
+    let stdout_filter: EnvFilter = "shishabot=debug,info".parse().unwrap();
+
+    let stdout_layer = Layer::default()
+        .event_format(StdoutEventFormat::default())
+        .with_filter(stdout_filter);
 
     let file_appender = rolling::daily("./logs", "shishabot.log");
     let (file_writer, guard) = NonBlocking::new(file_appender);
 
+    // Check RUST_LOG in .env, if it's not found it'll
+    // display ERROR, WARN, INFO, DEBUG, and TRACE from shishabot
+    // and ERROR, WARN, INFO from dependencies.
+    let file_filter = match EnvFilter::try_from_default_env() {
+        Ok(filter) => filter,
+        Err(_) => "shishabot=trace,info".parse().unwrap(),
+    };
+
     let file_layer = Layer::default()
-        .event_format(FileEventFormat::new(formatter))
-        .with_writer(file_writer);
+        .event_format(FileEventFormat::default())
+        .with_writer(file_writer)
+        .with_filter(file_filter);
 
-    let subscriber = FmtSubscriber::builder()
-        .with_env_filter(EnvFilter::from_default_env())
-        .with_target(false)
-        .with_timer(UtcTime::new(formatter))
-        .finish()
-        .with(file_layer);
-
-    tracing::subscriber::set_global_default(subscriber).expect("failed to set global subscriber");
+    tracing_subscriber::registry()
+        .with(stdout_layer)
+        .with(file_layer)
+        .init();
 
     guard
 }
 
-struct FileEventFormat<'f> {
-    timer: UtcTime<&'f [FormatItem<'f>]>,
+struct StdoutEventFormat {
+    timer: UtcTime<&'static [FormatItem<'static>]>,
 }
 
-impl<'f> FileEventFormat<'f> {
-    fn new(formatter: &'f [FormatItem<'f>]) -> Self {
+impl Default for StdoutEventFormat {
+    fn default() -> Self {
         Self {
-            timer: UtcTime::new(formatter),
+            timer: UtcTime::new(DATETIME_FORMAT),
         }
     }
 }
 
-impl<S, N> FormatEvent<S, N> for FileEventFormat<'_>
+impl<S, N> FormatEvent<S, N> for StdoutEventFormat
 where
     S: Subscriber + for<'a> LookupSpan<'a>,
     N: for<'a> FormatFields<'a> + 'static,
@@ -61,7 +76,41 @@ where
         ctx: &FmtContext<'_, S, N>,
         mut writer: Writer<'_>,
         event: &Event<'_>,
-    ) -> fmt::Result {
+    ) -> FmtResult {
+        self.timer.format_time(&mut writer)?;
+        let metadata = event.metadata();
+
+        write!(writer, " {:>5} ", metadata.level(),)?;
+
+        ctx.field_format().format_fields(writer.by_ref(), event)?;
+
+        writeln!(writer)
+    }
+}
+
+struct FileEventFormat {
+    timer: UtcTime<&'static [FormatItem<'static>]>,
+}
+
+impl Default for FileEventFormat {
+    fn default() -> Self {
+        Self {
+            timer: UtcTime::new(DATETIME_FORMAT),
+        }
+    }
+}
+
+impl<S, N> FormatEvent<S, N> for FileEventFormat
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> FmtResult {
         self.timer.format_time(&mut writer)?;
         let metadata = event.metadata();
 
@@ -78,3 +127,25 @@ where
         writeln!(writer)
     }
 }
+
+pub const DATE_FORMAT: &[FormatItem<'_>] = &[
+    FormatItem::Component(Component::Year(Year::default())),
+    FormatItem::Literal(b"-"),
+    FormatItem::Component(Component::Month(Month::default())),
+    FormatItem::Literal(b"-"),
+    FormatItem::Component(Component::Day(Day::default())),
+];
+
+pub const TIME_FORMAT: &[FormatItem<'_>] = &[
+    FormatItem::Component(Component::Hour(<Hour>::default())),
+    FormatItem::Literal(b":"),
+    FormatItem::Component(Component::Minute(<Minute>::default())),
+    FormatItem::Literal(b":"),
+    FormatItem::Component(Component::Second(<Second>::default())),
+];
+
+pub const DATETIME_FORMAT: &[FormatItem<'_>] = &[
+    FormatItem::Compound(DATE_FORMAT),
+    FormatItem::Literal(b" "),
+    FormatItem::Compound(TIME_FORMAT),
+];

--- a/src/core/logging.rs
+++ b/src/core/logging.rs
@@ -22,9 +22,9 @@ use tracing_subscriber::{
 };
 
 pub fn init() -> WorkerGuard {
-    // Displays ERROR, WARN, INFO, and DEBUG from shishabot
-    // and ERROR, WARN, INFO from dependencies
-    let stdout_filter: EnvFilter = "shishabot=debug,info".parse().unwrap();
+    // Displays ERROR, WARN, and INFO from shishabot
+    // and ERROR and WARN from dependencies
+    let stdout_filter: EnvFilter = "shishabot=info,warn".parse().unwrap();
 
     let stdout_layer = Layer::default()
         .event_format(StdoutEventFormat::default())

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ fn main() {
 
 async fn async_main() -> Result<()> {
     let _ = dotenv::dotenv().expect("failed to parse .env file");
-    let _log_worker_guard = logging::initialize();
+    let _log_worker_guard = logging::init();
 
     // Load config file
     BotConfig::init().context("failed to initialize config")?;


### PR DESCRIPTION
Logging to stdout and the file are now split.
Stdout will always receive `ERROR`, `WARN`, and `INFO` events from shishabot and `ERROR` and `WARN` from dependencies.
For the file it depends on the `RUST_LOG` variable in the `.env`. If it's present, it'll take that, otherwise it'll get `ERROR`, `WARN`, `INFO`, `DEBUG`, and __`TRACE`__ events from shishabot and `ERROR`, `WARN` and `INFO` from dependencies.