### PR TITLE
mirror download order update

### DIFF
--- a/src/core/replay_queue/process.rs
+++ b/src/core/replay_queue/process.rs
@@ -424,12 +424,12 @@ async fn download_mapset(ctx: &Context, mapset_id: u32) -> Result<()> {
 }
 
 async fn request_mapset(ctx: &Context, mapset_id: u32) -> Result<Bytes> {
-    let kitsu = match ctx.client().download_kitsu_mapset(mapset_id).await {
+    let chimu = match ctx.client().download_chimu_mapset(mapset_id).await {
         Ok(bytes) => return Ok(bytes),
         Err(err) => err,
     };
-
-    let chimu = match ctx.client().download_chimu_mapset(mapset_id).await {
+    
+    let kitsu = match ctx.client().download_kitsu_mapset(mapset_id).await {
         Ok(bytes) => return Ok(bytes),
         Err(err) => err,
     };


### PR DESCRIPTION
since kitsu.moe renamed to osu.direct, their api no longer works